### PR TITLE
fix: allow third-party module to use langchain agent

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -266,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/buhe/SwiftyNotion",
       "state" : {
-        "branch" : "main",
-        "revision" : "ccfe5600df5e315e48470ca840f682ec446869f8"
+        "revision" : "ccfe5600df5e315e48470ca840f682ec446869f8",
+        "version" : "0.1.5"
       }
     },
     {

--- a/Sources/LangChain/callbacks/BaseCallbackHandler.swift
+++ b/Sources/LangChain/callbacks/BaseCallbackHandler.swift
@@ -6,75 +6,79 @@
 //
 
 import Foundation
-public class BaseCallbackHandler: LLMManagerMixin, ChainManagerMixin, CallbackManagerMixin, ToolManagerMixin, LoaderManagerMixin {
+open class BaseCallbackHandler: LLMManagerMixin, ChainManagerMixin, CallbackManagerMixin, ToolManagerMixin, LoaderManagerMixin {
+    
+    public init() {
+        
+    }
     // Loader
-    public func on_loader_start(type: String, metadata: [String : String]) throws {
+    open func on_loader_start(type: String, metadata: [String : String]) throws {
         
     }
     
-    public func on_loader_error(type: String, cause: String, metadata: [String : String]) throws {
+    open func on_loader_error(type: String, cause: String, metadata: [String : String]) throws {
         
     }
     
-    public func on_loader_end(type: String, metadata: [String : String]) throws {
+    open func on_loader_end(type: String, metadata: [String : String]) throws {
         
     }
     
     // Agent
-    public func on_agent_start(prompt: String, metadata: [String : String]) throws {
+    open func on_agent_start(prompt: String, metadata: [String : String]) throws {
         
     }
     
-    public func on_llm_error(error: Error, metadata: [String: String]) throws {
+    open func on_llm_error(error: Error, metadata: [String: String]) throws {
         
     }
     
-    public func on_llm_start(prompt: String, metadata: [String: String]) throws {
+    open func on_llm_start(prompt: String, metadata: [String: String]) throws {
         
     }
     
     // Manage callback
-    public func on_chain_start(prompts: String, metadata: [String: String]) throws {
+    open func on_chain_start(prompts: String, metadata: [String: String]) throws {
         
     }
     
-    public func on_tool_start(tool: BaseTool, input: String, metadata: [String: String]) throws {
+    open func on_tool_start(tool: BaseTool, input: String, metadata: [String: String]) throws {
         
     }
     
     // Chain callback
-    public func on_chain_end(output: String, metadata: [String: String]) throws {
+    open func on_chain_end(output: String, metadata: [String: String]) throws {
         
     }
     
-    public func on_chain_error(error: Error, metadata: [String: String]) throws {
+    open func on_chain_error(error: Error, metadata: [String: String]) throws {
         
     }
     
-    public func on_agent_action(action: AgentAction, metadata: [String: String]) throws {
+    open func on_agent_action(action: AgentAction, metadata: [String: String]) throws {
         
     }
     
-    public func on_agent_finish(action: AgentFinish, metadata: [String: String]) throws {
+    open func on_agent_finish(action: AgentFinish, metadata: [String: String]) throws {
         
     }
 
     
     // LLM callback
-    public func on_llm_new_token(metadata: [String: String]) {
+    open func on_llm_new_token(metadata: [String: String]) {
         
     }
     
-    public func on_llm_end(output: String, metadata: [String: String]) throws {
+    open func on_llm_end(output: String, metadata: [String: String]) throws {
         
     }
     
     // Tool callback
-    public func on_tool_end(tool: BaseTool, output: String, metadata: [String: String]) throws {
+    open func on_tool_end(tool: BaseTool, output: String, metadata: [String: String]) throws {
         
     }
     
-    public func on_tool_error(error: Error, metadata: [String: String]) throws {
+    open func on_tool_error(error: Error, metadata: [String: String]) throws {
         
     }
 }

--- a/Sources/LangChain/parser/BaseOutputParser.swift
+++ b/Sources/LangChain/parser/BaseOutputParser.swift
@@ -9,12 +9,20 @@ import Foundation
 import SwiftyJSON
 
 public struct AgentAction{
-    let action: String
-    let input: String
-    let log: String
+    public let action: String
+    public let input: String
+    public let log: String
+    public init(action: String, input: String, log: String) {
+        self.action = action
+        self.input = input
+        self.log = log
+    }
 }
 public struct AgentFinish {
-    let final: String
+    public let final: String
+    public init(final: String) {
+        self.final = final
+    }
 }
 
 public enum Parsed {

--- a/Sources/LangChain/tools/InvalidTool.swift
+++ b/Sources/LangChain/tools/InvalidTool.swift
@@ -12,7 +12,7 @@ import Foundation
 public class InvalidTool: BaseTool {
     let tool_name: String
     
-    init(tool_name: String) {
+    public init(tool_name: String) {
         self.tool_name = tool_name
     }
     


### PR DESCRIPTION
Hi,  I've developed  a package to implement [LangGraph for Swift](https://github.com/bsorrentino/LangGraph-Swift.git).

In such package I've also built a demo converting to `LangGraph` the [AgentExecutor](https://github.com/buhe/langchain-swift/blob/main/Sources/LangChain/agents/Agent.swift). During such development I've figure out that there are some `access level`  to change and these are contained in the PR